### PR TITLE
Omit media scope when registering active_admin.css

### DIFF
--- a/lib/active_admin/application.rb
+++ b/lib/active_admin/application.rb
@@ -165,7 +165,7 @@ module ActiveAdmin
     private
 
     def register_default_assets
-      register_stylesheet "active_admin.css", media: "all"
+      register_stylesheet "active_admin.css"
       register_javascript "active_admin.js"
     end
 


### PR DESCRIPTION
This is an attempted fix for `ActionView::Template::Error: Webpacker can't find {:media=>"all"}.css in /app/public/packs/manifest.json.` exceptions with Rails 7.0.1 on staging